### PR TITLE
API-5566: Upgrade HMRC Play Bootstrap library

### DIFF
--- a/app/uk/gov/hmrc/integrationcataloguefrontend/controllers/FileTransferController.scala
+++ b/app/uk/gov/hmrc/integrationcataloguefrontend/controllers/FileTransferController.scala
@@ -24,7 +24,7 @@ import uk.gov.hmrc.integrationcataloguefrontend.config.AppConfig
 import uk.gov.hmrc.integrationcataloguefrontend.services.IntegrationService
 import uk.gov.hmrc.integrationcataloguefrontend.views.html.ErrorTemplate
 import uk.gov.hmrc.integrationcataloguefrontend.views.html.filetransfer.wizard._
-import uk.gov.hmrc.play.bootstrap.controller.WithDefaultFormBinding
+import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
 import javax.inject.{Inject, Singleton}
@@ -44,7 +44,7 @@ class FileTransferController @Inject() (
   )(implicit val ec: ExecutionContext)
     extends FrontendController(mcc)
       with FtWizardHelper
-      with WithDefaultFormBinding {
+      with WithUnsafeDefaultFormBinding {
 
   implicit val config: AppConfig = appConfig
 

--- a/app/uk/gov/hmrc/integrationcataloguefrontend/controllers/IntegrationController.scala
+++ b/app/uk/gov/hmrc/integrationcataloguefrontend/controllers/IntegrationController.scala
@@ -30,7 +30,7 @@ import uk.gov.hmrc.integrationcataloguefrontend.views.html.filetransfer.FileTran
 import uk.gov.hmrc.integrationcataloguefrontend.views.html.integrations.ListIntegrationsView
 import uk.gov.hmrc.integrationcataloguefrontend.views.html.technicaldetails.{ApiTechnicalDetailsView, ApiTechnicalDetailsViewRedoc}
 import uk.gov.hmrc.integrationcataloguefrontend.views.html.{ApiNotFoundErrorTemplate, ErrorTemplate}
-import uk.gov.hmrc.play.bootstrap.controller.WithDefaultFormBinding
+import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
 import javax.inject.{Inject, Singleton}
@@ -55,7 +55,7 @@ class IntegrationController @Inject() (
     extends FrontendController(mcc)
     with Logging
     with ListIntegrationsHelper
-    with WithDefaultFormBinding {
+    with WithUnsafeDefaultFormBinding {
 
   implicit val config: AppConfig = appConfig
 

--- a/app/uk/gov/hmrc/integrationcataloguefrontend/controllers/QuickSearchController.scala
+++ b/app/uk/gov/hmrc/integrationcataloguefrontend/controllers/QuickSearchController.scala
@@ -21,7 +21,7 @@ import play.api.libs.json.Json
 import play.api.mvc._
 import uk.gov.hmrc.integrationcatalogue.models.ApiDetailSummary.fromIntegrationDetail
 import uk.gov.hmrc.integrationcatalogue.models.common.PlatformType
-import uk.gov.hmrc.integrationcatalogue.models.{ApiDetail, ApiDetailSummary, DynamicPageResponse, IntegrationFilter, JsonFormatters}
+import uk.gov.hmrc.integrationcatalogue.models.{DynamicPageResponse, IntegrationFilter, JsonFormatters}
 import uk.gov.hmrc.integrationcataloguefrontend.config.AppConfig
 import uk.gov.hmrc.integrationcataloguefrontend.services.IntegrationService
 import uk.gov.hmrc.integrationcataloguefrontend.views.html.dynamic.DynamicListView

--- a/app/uk/gov/hmrc/integrationcataloguefrontend/views/filetransfer/wizard/FileTransferWizardDataSource.scala.html
+++ b/app/uk/gov/hmrc/integrationcataloguefrontend/views/filetransfer/wizard/FileTransferWizardDataSource.scala.html
@@ -35,7 +35,7 @@
           Where is your data currently stored?
         </span>
       </legend>
-      @helper.form(action = uk.gov.hmrc.integrationcataloguefrontend.controllers.routes.FileTransferController.dataSourceAction(), 'class -> "form", 'id -> "selectedDataSourceForm") {
+      @helper.form(action = uk.gov.hmrc.integrationcataloguefrontend.controllers.routes.FileTransferController.dataSourceAction, 'class -> "form", 'id -> "selectedDataSourceForm") {
         @helper.CSRF.formField
         <span id="dataSource"></span>
         @if(form.hasErrors) {
@@ -59,7 +59,7 @@
     </fieldset>
   </div>
 
-  <a id="hod-link" href="@uk.gov.hmrc.integrationcataloguefrontend.controllers.routes.MainController.contactPage()" class="govuk-link govuk-link--no-visited-state govuk-body-m">
+  <a id="hod-link" href="@uk.gov.hmrc.integrationcataloguefrontend.controllers.routes.MainController.contactPage" class="govuk-link govuk-link--no-visited-state govuk-body-m">
     The HoD I want isn’t listed
   </a>
 }

--- a/app/uk/gov/hmrc/integrationcataloguefrontend/views/filetransfer/wizard/FileTransferWizardDataTarget.scala.html
+++ b/app/uk/gov/hmrc/integrationcataloguefrontend/views/filetransfer/wizard/FileTransferWizardDataTarget.scala.html
@@ -58,7 +58,7 @@
       }
     </fieldset>
   </div>
-  <a id="hod-link" href="@uk.gov.hmrc.integrationcataloguefrontend.controllers.routes.MainController.contactPage()" class="govuk-link govuk-link--no-visited-state govuk-body-m">
+  <a id="hod-link" href="@uk.gov.hmrc.integrationcataloguefrontend.controllers.routes.MainController.contactPage" class="govuk-link govuk-link--no-visited-state govuk-body-m">
     The HoD I want isn’t listed
   </a>
 }

--- a/app/uk/gov/hmrc/integrationcataloguefrontend/views/includes/BackendsFilterComponent.scala.html
+++ b/app/uk/gov/hmrc/integrationcataloguefrontend/views/includes/BackendsFilterComponent.scala.html
@@ -40,7 +40,7 @@
 
         </div>
     </fieldset>
-    <p class="govuk-body-s"><br/><a id="contactlink" href="@uk.gov.hmrc.integrationcataloguefrontend.controllers.routes.MainController.contactPage()" class="govuk-link govuk-link--no-visited-state">
+    <p class="govuk-body-s"><br/><a id="contactlink" href="@uk.gov.hmrc.integrationcataloguefrontend.controllers.routes.MainController.contactPage" class="govuk-link govuk-link--no-visited-state">
         The HoD I want isn’t listed
     </a>
     </p>

--- a/app/uk/gov/hmrc/integrationcataloguefrontend/views/includes/FooterWithItems.scala.html
+++ b/app/uk/gov/hmrc/integrationcataloguefrontend/views/includes/FooterWithItems.scala.html
@@ -27,7 +27,7 @@
 @footerlinkItems()  = @{
     Seq( FooterItem(
         Some(messages("footer.links.accessibility.text")),
-        Some(uk.gov.hmrc.integrationcataloguefrontend.controllers.routes.MainController.accessibilityStatementPage().url)
+        Some(uk.gov.hmrc.integrationcataloguefrontend.controllers.routes.MainController.accessibilityStatementPage.url)
     ))
 }
 

--- a/build.sbt
+++ b/build.sbt
@@ -43,7 +43,7 @@ lazy val microservice = Project(appName, file("."))
     IntegrationTest / parallelExecution := false,
     IntegrationTest / unmanagedSourceDirectories += baseDirectory(_ / "test-common").value,
     IntegrationTest / unmanagedSourceDirectories += baseDirectory(_ / "it").value,
-    (managedClasspath in IntegrationTest) += (packageBin in Assets).value
+    IntegrationTest / managedClasspath += (Assets / packageBin).value
   )
   .configs(ComponentTest)
   .settings(inConfig(ComponentTest)(Defaults.testSettings): _*)
@@ -54,7 +54,7 @@ lazy val microservice = Project(appName, file("."))
     ComponentTest / unmanagedResourceDirectories += baseDirectory.value / "test",
     ComponentTest / unmanagedResourceDirectories += baseDirectory.value / "target" / "web" / "public" / "test",
     ComponentTest / testOptions += Tests.Setup(() => System.setProperty("javascript.enabled", "true")),
-    ComponentTest / testGrouping := oneForkedJvmPerTest((definedTests in ComponentTest).value),
+    ComponentTest / testGrouping := oneForkedJvmPerTest((ComponentTest / definedTests).value),
     ComponentTest / parallelExecution := false
   )
 
@@ -69,6 +69,6 @@ lazy val microservice = Project(appName, file("."))
       ScoverageKeys.coverageMinimumBranchTotal := 85,
       ScoverageKeys.coverageFailOnMinimum := true,
       ScoverageKeys.coverageHighlighting := true,
-      parallelExecution in Test := false
+      Test / parallelExecution := false
   )
 }

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -6,8 +6,8 @@ import sbt._
 object AppDependencies {
   lazy val scalaCheckVersion = "1.14.0"
   lazy val enumeratumVersion = "1.6.3"
-  lazy val jacksonVersion = "2.11.1"
-  lazy val bootstrapVersion = "5.24.0"
+  lazy val jacksonVersion = "2.12.2"
+  lazy val bootstrapVersion = "7.12.0"
   lazy val playFrontendVersion = "3.20.0-play-28"
   lazy val cucumberVersion = "6.2.2"
   lazy val seleniumVersion = "2.53.1"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.9
+sbt.version=1.6.2

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -9,7 +9,7 @@ addSbtPlugin("uk.gov.hmrc" % "sbt-git-versioning" % "2.2.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.1.0")
 
-addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.7")
+addSbtPlugin("com.typesafe.play" % "sbt-plugin" % "2.8.18")
 
 addSbtPlugin("org.irundaia.sbt" % "sbt-sassify" % "1.4.11")
 

--- a/test/uk/gov/hmrc/integrationcataloguefrontend/connectors/EmailConnectorSpec.scala
+++ b/test/uk/gov/hmrc/integrationcataloguefrontend/connectors/EmailConnectorSpec.scala
@@ -16,7 +16,6 @@
 
 package uk.gov.hmrc.integrationcataloguefrontend.connectors
 
-import org.mockito.captor.{ArgCaptor, Captor}
 import org.mockito.stubbing.ScalaOngoingStubbing
 import play.api.http.Status.{ACCEPTED, BAD_REQUEST, INTERNAL_SERVER_ERROR}
 import play.api.libs.json.Writes

--- a/test/uk/gov/hmrc/integrationcataloguefrontend/controllers/QuickSearchControllerSpec.scala
+++ b/test/uk/gov/hmrc/integrationcataloguefrontend/controllers/QuickSearchControllerSpec.scala
@@ -29,7 +29,6 @@ import uk.gov.hmrc.integrationcataloguefrontend.test.data.{ApiTestData, FileTran
 import uk.gov.hmrc.integrationcataloguefrontend.utils.AsyncHmrcSpec
 import uk.gov.hmrc.integrationcataloguefrontend.views.helper.WithCSRFAddToken
 import uk.gov.hmrc.integrationcataloguefrontend.views.html.dynamic.DynamicListView
-import uk.gov.hmrc.integrationcataloguefrontend.views.html.integrations.ListIntegrationsView
 import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 import uk.gov.hmrc.play.bootstrap.tools.Stubs.stubMessagesControllerComponents
 

--- a/test/uk/gov/hmrc/integrationcataloguefrontend/views/contact/ContactApiTeamViewSpec.scala
+++ b/test/uk/gov/hmrc/integrationcataloguefrontend/views/contact/ContactApiTeamViewSpec.scala
@@ -18,11 +18,9 @@ package uk.gov.hmrc.integrationcataloguefrontend.views.contact
 
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
-import play.api.mvc.{AnyContent, Request}
 import play.api.test.CSRFTokenHelper.CSRFRequest
 import play.api.test.FakeRequest
 import play.twirl.api.Html
-import uk.gov.hmrc.integrationcatalogue.models.ApiDetail
 import uk.gov.hmrc.integrationcataloguefrontend.controllers.ContactApiTeamForm
 import uk.gov.hmrc.integrationcataloguefrontend.test.data.ApiTestData
 import uk.gov.hmrc.integrationcataloguefrontend.views.helper.CommonViewSpec
@@ -33,7 +31,7 @@ class ContactApiTeamViewSpec extends CommonViewSpec with ApiTestData {
 
   trait Setup {
     val contactApiTeamView = app.injector.instanceOf[ContactApiTeamView]
-    val fakeRequest = FakeRequest().withCSRFToken.withBody()
+    val fakeRequest = FakeRequest().withCSRFToken
   }
 
   "ContactApiTeamPage" should {

--- a/test/uk/gov/hmrc/integrationcataloguefrontend/views/filetransfer/wizard/FileTransferWizardDataSourceSpec.scala
+++ b/test/uk/gov/hmrc/integrationcataloguefrontend/views/filetransfer/wizard/FileTransferWizardDataSourceSpec.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.integrationcataloguefrontend.views.filetransfer.wizard
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import play.api.test.FakeRequest
-import play.api.test.CSRFTokenHelper._
+import play.api.test.CSRFTokenHelper.CSRFRequest
 import play.twirl.api.Html
 import uk.gov.hmrc.integrationcataloguefrontend.controllers.SelectedDataSourceForm
 import uk.gov.hmrc.integrationcataloguefrontend.views.helper.CommonViewSpec
@@ -34,7 +34,7 @@ class FileTransferWizardDataSourceSpec extends CommonViewSpec with FileTransferR
   "FT wizard data source page" should {
 
     "render page correctly" in new Setup {
-      val page: Html = dataSourcePage.render(SelectedDataSourceForm.form, FakeRequest().withCSRFToken.withBody(), messagesProvider.messages, appConfig)
+      val page: Html = dataSourcePage.render(SelectedDataSourceForm.form, FakeRequest().withCSRFToken, messagesProvider.messages, appConfig)
       val document: Document = Jsoup.parse(page.body)
       document.title shouldBe "Where is your data currently stored? -"
       document.getElementById("page-heading").text() shouldBe "Where is your data currently stored?"
@@ -50,7 +50,7 @@ class FileTransferWizardDataSourceSpec extends CommonViewSpec with FileTransferR
     }
 
     "render page correctly with errors" in new Setup {
-      val page: Html = dataSourcePage.render(SelectedDataSourceForm.form.withError("dataSource", "error"), FakeRequest().withCSRFToken.withBody(), messagesProvider.messages, appConfig)
+      val page: Html = dataSourcePage.render(SelectedDataSourceForm.form.withError("dataSource", "error"), FakeRequest().withCSRFToken, messagesProvider.messages, appConfig)
       val document: Document = Jsoup.parse(page.body)
 
       document.getElementById("page-heading").text() shouldBe "Where is your data currently stored?"

--- a/test/uk/gov/hmrc/integrationcataloguefrontend/views/filetransfer/wizard/FileTransferWizardDataTargetSpec.scala
+++ b/test/uk/gov/hmrc/integrationcataloguefrontend/views/filetransfer/wizard/FileTransferWizardDataTargetSpec.scala
@@ -19,7 +19,7 @@ package uk.gov.hmrc.integrationcataloguefrontend.views.filetransfer.wizard
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 import play.api.test.FakeRequest
-import play.api.test.CSRFTokenHelper._
+import play.api.test.CSRFTokenHelper.CSRFRequest
 import play.twirl.api.Html
 import uk.gov.hmrc.integrationcataloguefrontend.views.helper.CommonViewSpec
 import uk.gov.hmrc.integrationcataloguefrontend.views.html.filetransfer.wizard.FileTransferWizardDataTarget
@@ -34,7 +34,7 @@ class FileTransferWizardDataTargetSpec extends CommonViewSpec with FileTransferR
   "FT wizard data target page" should {
 
     "render page correctly" in new Setup {
-      val page: Html = dataTargetPage.render(SelectedDataTargetForm.form, "source", FakeRequest().withCSRFToken.withBody(), messagesProvider.messages, appConfig)
+      val page: Html = dataTargetPage.render(SelectedDataTargetForm.form, "source", FakeRequest().withCSRFToken, messagesProvider.messages, appConfig)
       val document: Document = Jsoup.parse(page.body)
       document.title shouldBe "Where do you want to send your data? -"
       document.getElementById("page-heading").text() shouldBe "Where do you want to send your data?"
@@ -52,7 +52,7 @@ class FileTransferWizardDataTargetSpec extends CommonViewSpec with FileTransferR
     }
 
     "render page correctly with errors" in new Setup {
-      val page: Html = dataTargetPage.render(SelectedDataTargetForm.form.withError("dataSource", "error"), "source", FakeRequest().withCSRFToken.withBody(), messagesProvider.messages, appConfig)
+      val page: Html = dataTargetPage.render(SelectedDataTargetForm.form.withError("dataSource", "error"), "source", FakeRequest().withCSRFToken, messagesProvider.messages, appConfig)
       val document: Document = Jsoup.parse(page.body)
 
       document.getElementById("page-heading").text() shouldBe "Where do you want to send your data?"

--- a/test/uk/gov/hmrc/integrationcataloguefrontend/views/technicaldetails/ApiTechnicalDetailsViewSpec.scala
+++ b/test/uk/gov/hmrc/integrationcataloguefrontend/views/technicaldetails/ApiTechnicalDetailsViewSpec.scala
@@ -19,7 +19,6 @@ package uk.gov.hmrc.integrationcataloguefrontend.views.technicaldetails
 import uk.gov.hmrc.integrationcataloguefrontend.views.html.technicaldetails.ApiTechnicalDetailsView
 import uk.gov.hmrc.integrationcataloguefrontend.views.helper.CommonViewSpec
 import uk.gov.hmrc.integrationcataloguefrontend.test.data.ApiTestData
-import play.api.test.FakeRequest
 import uk.gov.hmrc.integrationcatalogue.models.ApiDetail
 import play.twirl.api.Html
 import org.jsoup.nodes.Document


### PR DESCRIPTION
For the change from `WithDefaultFormBinding` to `WithUnsafeDefaultFormBinding`, see https://github.com/hmrc/bootstrap-play#form-bindings