### PR TITLE
hipp-660 feat: add csp to technical api details page

### DIFF
--- a/app/uk/gov/hmrc/integrationcataloguefrontend/views/technicaldetails/ApiTechnicalDetailsView.scala.html
+++ b/app/uk/gov/hmrc/integrationcataloguefrontend/views/technicaldetails/ApiTechnicalDetailsView.scala.html
@@ -16,6 +16,7 @@
 
 @import uk.gov.hmrc.integrationcataloguefrontend.config.AppConfig
 @import uk.gov.hmrc.integrationcatalogue.models.ApiDetail
+@import views.html.helper.CSPNonce
 
 @this(layout: BareLayout)
 
@@ -26,11 +27,11 @@
 
   <div id="swagger-ui"></div>
   
-  <script src='@controllers.routes.Assets.versioned("javascripts/swagger-ui-bundle.js")' charset="UTF-8"> </script>
-  <script src='@controllers.routes.Assets.versioned("javascripts/swagger-ui-standalone-preset.js")' charset="UTF-8"> </script>
+  <script src='@controllers.routes.Assets.versioned("javascripts/swagger-ui-bundle.js")' charset="UTF-8" @{CSPNonce.attr}> </script>
+  <script src='@controllers.routes.Assets.versioned("javascripts/swagger-ui-standalone-preset.js")' charset="UTF-8" @{CSPNonce.attr}> </script>
   <link rel="stylesheet" type="text/css" href='@controllers.routes.Assets.versioned("stylesheets/swagger-ui.css")' />
   
-  <script>
+  <script @{CSPNonce.attr}>
     window.onload = function() {
 
       // Begin Swagger UI call region


### PR DESCRIPTION
Testing by running up the frontend and it's dependencies. Visited http://localhost:11112/api-catalogue/integrations/d8ba12ee-5fe1-4487-a652-6e0f8a507236/alvs-clearance-outbound/technical and checked the page worked and also checked the CONTENT_SECURITY_POLICY_REPORTS logs didn't show any errors.