### PR TITLE
HIPP-1425: Redirect users from Catalogue pages to the Integration Hub

### DIFF
--- a/app/uk/gov/hmrc/integrationcataloguefrontend/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/integrationcataloguefrontend/config/AppConfig.scala
@@ -40,10 +40,6 @@ class AppConfig @Inject() (config: Configuration, servicesConfig: ServicesConfig
   val internalAuthToken: String = config.get[String]("internal-auth.token")
 
   val apiHubApiDetailsUrl: String = config.get[String]("urls.apiHub.apiDetails")
-  val apiHubGetStartedUrl: String = config.get[String]("urls.apiHub.getStarted")
   val apiHubAPIsUrl: String = config.get[String]("urls.apiHub.apis")
-  val apiHubAboutUrl: String = config.get[String]("urls.apiHub.aboutUrl")
-  val apiHubCaseStudiesUrl: String = config.get[String]("urls.apiHub.caseStudies")
-  val apiHubContactUrl: String = config.get[String]("urls.apiHub.contactUrl")
 
 }

--- a/app/uk/gov/hmrc/integrationcataloguefrontend/config/AppConfig.scala
+++ b/app/uk/gov/hmrc/integrationcataloguefrontend/config/AppConfig.scala
@@ -40,5 +40,10 @@ class AppConfig @Inject() (config: Configuration, servicesConfig: ServicesConfig
   val internalAuthToken: String = config.get[String]("internal-auth.token")
 
   val apiHubApiDetailsUrl: String = config.get[String]("urls.apiHub.apiDetails")
+  val apiHubGetStartedUrl: String = config.get[String]("urls.apiHub.getStarted")
+  val apiHubAPIsUrl: String = config.get[String]("urls.apiHub.apis")
+  val apiHubAboutUrl: String = config.get[String]("urls.apiHub.aboutUrl")
+  val apiHubCaseStudiesUrl: String = config.get[String]("urls.apiHub.caseStudies")
+  val apiHubContactUrl: String = config.get[String]("urls.apiHub.contactUrl")
 
 }

--- a/app/uk/gov/hmrc/integrationcataloguefrontend/views/includes/HeaderNavigationLinks.scala.html
+++ b/app/uk/gov/hmrc/integrationcataloguefrontend/views/includes/HeaderNavigationLinks.scala.html
@@ -14,10 +14,12 @@
  * limitations under the License.
  *@
 
+@import uk.gov.hmrc.integrationcataloguefrontend.config.AppConfig
+
 @this(searchBox: SearchBox)
 
 
-@(activePage: Option[String], includeSearch: Boolean)
+@(activePage: Option[String], includeSearch: Boolean)(implicit config: AppConfig)
 
 @handleLinkClasses(expectedPage: String)= @{
     val activeClass = "govuk-sub-nav-link govuk-sub-nav-link--active"
@@ -37,7 +39,11 @@
         <div class="two">
             <ul id="navigation" class="govuk-sub-nav-links" aria-label="Navigation links">
                 <li class='@handleLinkClasses("list-apis")'>
-                    <a id="nav-apis-link" href="@uk.gov.hmrc.integrationcataloguefrontend.controllers.routes.IntegrationController.listIntegrations(None, List.empty, List.empty, None, None)" class="govuk-header__link">APIs</a>
+                    <a id="nav-get-started-link" href="@config.apiHubGetStartedUrl" class="govuk-header__link">Get started</a>
+                </li>
+                          
+                <li class='@handleLinkClasses("list-apis")'>
+                    <a id="nav-apis-link" href="@config.apiHubAPIsUrl" class="govuk-header__link">APIs</a>
                 </li>
 
                 <li class='@handleLinkClasses("list-apis")'>

--- a/app/uk/gov/hmrc/integrationcataloguefrontend/views/includes/HeaderNavigationLinks.scala.html
+++ b/app/uk/gov/hmrc/integrationcataloguefrontend/views/includes/HeaderNavigationLinks.scala.html
@@ -37,11 +37,7 @@
             </div>
         }
         <div class="two">
-            <ul id="navigation" class="govuk-sub-nav-links" aria-label="Navigation links">
-                <li class='@handleLinkClasses("list-apis")'>
-                    <a id="nav-get-started-link" href="@config.apiHubGetStartedUrl" class="govuk-header__link">Get started</a>
-                </li>
-                          
+            <ul id="navigation" class="govuk-sub-nav-links" aria-label="Navigation links">                          
                 <li class='@handleLinkClasses("list-apis")'>
                     <a id="nav-apis-link" href="@config.apiHubAPIsUrl" class="govuk-header__link">APIs</a>
                 </li>

--- a/app/uk/gov/hmrc/integrationcataloguefrontend/views/includes/SiteHeader.scala.html
+++ b/app/uk/gov/hmrc/integrationcataloguefrontend/views/includes/SiteHeader.scala.html
@@ -14,9 +14,11 @@
  * limitations under the License.
  *@
 
+@import uk.gov.hmrc.integrationcataloguefrontend.config.AppConfig
+
 @this(navLinks: HeaderNavigationLinks, hmrcInternalHeader: HmrcInternalHeader)
 
-@(activePage: Option[String] = None, includeSearch: Boolean = false)(implicit messages: Messages)
+@(activePage: Option[String] = None, includeSearch: Boolean = false)(implicit messages: Messages, appConfig: AppConfig)
 
 @hmrcInternalHeader(InternalHeader(
     homepageUrl = "https://www.gov.uk/government/organisations/hm-revenue-customs",

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -70,6 +70,7 @@ google-analytics {
 }
 
 platform.frontend.host = "http://localhost:9000"
+apiHub.host = "http://localhost:15018"
 
 survey.link = "https://www.gov.uk"
 
@@ -93,7 +94,12 @@ search {
 
 urls {
   apiHub {
-    apiDetails = "http://localhost:15018/api-hub/apis/details/"
+    apiDetails = ${apiHub.host}"/api-hub/apis/details/"
+    getStarted = ${apiHub.host}"/api-hub"
+    apis = ${apiHub.host}"/api-hub/apis"
+    aboutUrl = ${apiHub.host}"/api-hub"
+    caseStudies = ${apiHub.host}"/api-hub"
+    contactUrl = ${apiHub.host}"/api-hub/get-support"
   }
   footer {
     govukHelp = "https://www.gov.uk/help"

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -70,7 +70,7 @@ google-analytics {
 }
 
 platform.frontend.host = "http://localhost:9000"
-apiHub.host = "http://localhost:15018"
+apiHub.baseUrl = "http://localhost:15018/integration-hub"
 
 survey.link = "https://www.gov.uk"
 
@@ -94,12 +94,8 @@ search {
 
 urls {
   apiHub {
-    apiDetails = ${apiHub.host}"/api-hub/apis/details/"
-    getStarted = ${apiHub.host}"/api-hub"
-    apis = ${apiHub.host}"/api-hub/apis"
-    aboutUrl = ${apiHub.host}"/api-hub"
-    caseStudies = ${apiHub.host}"/api-hub"
-    contactUrl = ${apiHub.host}"/api-hub/get-support"
+    apiDetails = ${apiHub.baseUrl}"/apis/details/"
+    apis = ${apiHub.baseUrl}"/apis"
   }
   footer {
     govukHelp = "https://www.gov.uk/help"

--- a/test/uk/gov/hmrc/integrationcataloguefrontend/views/includes/HeaderNavigationLinksSpec.scala
+++ b/test/uk/gov/hmrc/integrationcataloguefrontend/views/includes/HeaderNavigationLinksSpec.scala
@@ -19,10 +19,13 @@ package uk.gov.hmrc.integrationcataloguefrontend.views.includes
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 
+import play.api.{Configuration, Environment}
 import play.twirl.api.Html
 
+import uk.gov.hmrc.integrationcataloguefrontend.config.AppConfig
 import uk.gov.hmrc.integrationcataloguefrontend.views.helper.CommonViewSpec
 import uk.gov.hmrc.integrationcataloguefrontend.views.html.includes.HeaderNavigationLinks
+import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 class HeaderNavigationLinksSpec extends CommonViewSpec {
 
@@ -33,11 +36,16 @@ class HeaderNavigationLinksSpec extends CommonViewSpec {
   "HeaderNavigationLinks" should {
 
     "render the Navigation Links component correctly No SearchBar" in new Setup {
-      val page: Html         = navLinks.render(None, includeSearch = false)
+      val env                = Environment.simple()
+      val configuration      = Configuration.load(env)
+
+      val serviceConfig      = new ServicesConfig(configuration)
+      val appConfig          = new AppConfig(configuration, serviceConfig)
+      val page: Html         = navLinks.render(None, includeSearch = false, config = appConfig)
       val document: Document = Jsoup.parse(page.body)
 
       document.getElementById("nav-apis-link").text() shouldBe "APIs"
-      document.getElementById("nav-apis-link").attr("href") shouldBe "/api-catalogue/search"
+      document.getElementById("nav-apis-link").attr("href") shouldBe "http://localhost:15018/api-hub/apis"
 
       document.getElementById("nav-file-transfers-link").text() shouldBe "File transfers"
       document.getElementById("nav-file-transfers-link").attr("href") shouldBe "/api-catalogue/filetransfer/wizard/start"

--- a/test/uk/gov/hmrc/integrationcataloguefrontend/views/includes/HeaderNavigationLinksSpec.scala
+++ b/test/uk/gov/hmrc/integrationcataloguefrontend/views/includes/HeaderNavigationLinksSpec.scala
@@ -45,7 +45,7 @@ class HeaderNavigationLinksSpec extends CommonViewSpec {
       val document: Document = Jsoup.parse(page.body)
 
       document.getElementById("nav-apis-link").text() shouldBe "APIs"
-      document.getElementById("nav-apis-link").attr("href") shouldBe "http://localhost:15018/api-hub/apis"
+      document.getElementById("nav-apis-link").attr("href") shouldBe "http://localhost:15018/integration-hub/apis"
 
       document.getElementById("nav-file-transfers-link").text() shouldBe "File transfers"
       document.getElementById("nav-file-transfers-link").attr("href") shouldBe "/api-catalogue/filetransfer/wizard/start"

--- a/test/uk/gov/hmrc/integrationcataloguefrontend/views/includes/SiteHeaderSpec.scala
+++ b/test/uk/gov/hmrc/integrationcataloguefrontend/views/includes/SiteHeaderSpec.scala
@@ -19,10 +19,13 @@ package uk.gov.hmrc.integrationcataloguefrontend.views.includes
 import org.jsoup.Jsoup
 import org.jsoup.nodes.Document
 
+import play.api.{Configuration, Environment}
 import play.twirl.api.Html
 
+import uk.gov.hmrc.integrationcataloguefrontend.config.AppConfig
 import uk.gov.hmrc.integrationcataloguefrontend.views.helper.CommonViewSpec
 import uk.gov.hmrc.integrationcataloguefrontend.views.html.includes.SiteHeader
+import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 
 class SiteHeaderSpec extends CommonViewSpec {
 
@@ -33,7 +36,12 @@ class SiteHeaderSpec extends CommonViewSpec {
   "SiteHeader" should {
 
     "render The main header correctly" in new Setup {
-      val page: Html         = siteHeader.render(None, includeSearch = false, messagesProvider.messages)
+      val env                = Environment.simple()
+      val configuration      = Configuration.load(env)
+
+      val serviceConfig      = new ServicesConfig(configuration)
+      val appConfig          = new AppConfig(configuration, serviceConfig)
+      val page: Html         = siteHeader.render(None, includeSearch = false, messagesProvider.messages, appConfig)
       val document: Document = Jsoup.parse(page.body)
 
       document.getElementsByClass("hmrc-internal-header__logo-text").first().text() shouldBe "HM Revenue & Customs"


### PR DESCRIPTION
Navlinks on the catalogue are pointing to the API Hub now ([#HIPP-1425](https://jira.tools.tax.service.gov.uk/browse/HIPP-1425))
Won't merge until the api-hub host configuration is on the `app-config-env` repos.