### PR TITLE
HIPP-1425: Fix styling on banner with overflowing text

### DIFF
--- a/app/assets/stylesheets/_custom.scss
+++ b/app/assets/stylesheets/_custom.scss
@@ -437,13 +437,17 @@ pre {
       margin-bottom: 0;
       margin-top: 40px;
     }
-    &__content:not(.white-space-unset) {
+    &__content {
       white-space: nowrap;
     }
     &-spacing {
       display: block;
     }
   }
+}
+
+.white-space-unset {
+  white-space: unset !important;
 }
 
 .govuk-custom-padding-right {


### PR DESCRIPTION
For some reason the existing SCSS syntax didn't work on qa:
![image](https://github.com/user-attachments/assets/1752c078-114d-449e-a267-cbd090b8db21)

[Screencast from 13-08-24 11:17:54.webm](https://github.com/user-attachments/assets/d7a0b392-e2c4-4b41-895e-87015c87cadc)

